### PR TITLE
Allow for empty replacement strings

### DIFF
--- a/tasks/sed.js
+++ b/tasks/sed.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
       return;
     }
 
-    if (!data.replacement) {
+    if (typeof data.replacement != 'undefined') {
       log.error('Missing replacement property.');
       return;
     }


### PR DESCRIPTION
The current check on the replacement property doesn't allow for empty strings, which is useful if you just want to remove some text out of files.
