### PR TITLE
Add main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "engines": {
     "node": ">=0.8.0"
   },
+  "main": "tasks/sed.js",
   "scripts": {
     "test": "/usr/bin/env node test/test.js"
   },


### PR DESCRIPTION
This way, things don't blow up in case someone decides to require('grunt-sed').
